### PR TITLE
Added some basic header info.

### DIFF
--- a/odin-mode.el
+++ b/odin-mode.el
@@ -1,4 +1,13 @@
-;; odin-mode.el - A minor mode for odin
+;;; odin-mode.el --- A minor mode for odin
+
+;; Author: mattt-b
+;; Keywords: odin, language, languages, mode
+;; Package-Requires: ((emacs "24.1"))
+;; Homepage: https://github.com/mattt-b/odin-mode
+
+;; This file is NOT part of GNU Emacs.
+
+;;; Code:
 
 (require 'cl)
 (require 'rx)

--- a/odin-mode.el
+++ b/odin-mode.el
@@ -1,9 +1,9 @@
 ;;; odin-mode.el --- A minor mode for odin
 
-;; Author: mattt-b
+;; Author: Ethan Morgan
 ;; Keywords: odin, language, languages, mode
 ;; Package-Requires: ((emacs "24.1"))
-;; Homepage: https://github.com/mattt-b/odin-mode
+;; Homepage: https://github.com/glassofethanol/odin-mode
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
This was done because trying to install odin-mode with [quelpa-use-package](https://github.com/quelpa/quelpa-use-package) was resulting in complaints about a missing package header. I'm not entirely sure what the requirements for package headers are, or if the attributes I added are entirely correct, but I can now install this package using quelpa.