### PR TITLE
Fix single quote

### DIFF
--- a/odin-mode.el
+++ b/odin-mode.el
@@ -22,7 +22,8 @@
     (modify-syntax-entry ?\\ "\\" table)
 
     ;; additional symbols
-    (modify-syntax-entry ?' "/" table)
+    (modify-syntax-entry ?' "\"" table)
+    (modify-syntax-entry ?` "\"" table)
     (modify-syntax-entry ?: "." table)
     (modify-syntax-entry ?+ "." table)
     (modify-syntax-entry ?- "." table)
@@ -191,7 +192,7 @@
     (,(odin-keywords-rx odin-constants) 1 font-lock-constant-face)
 
     ;; Strings
-    ("\\\".*\\\"" . font-lock-string-face)
+    ;; ("\\\".*\\\"" . font-lock-string-face)
 
     ;; Numbers
     (,(odin-wrap-word-rx odin-number-rx) . font-lock-constant-face)

--- a/odin-mode.el
+++ b/odin-mode.el
@@ -22,7 +22,7 @@
     (modify-syntax-entry ?\\ "\\" table)
 
     ;; additional symbols
-    (modify-syntax-entry ?' "." table)
+    (modify-syntax-entry ?' "/" table)
     (modify-syntax-entry ?: "." table)
     (modify-syntax-entry ?+ "." table)
     (modify-syntax-entry ?- "." table)
@@ -179,7 +179,7 @@
     (,(odin-keywords-rx odin-keywords) 1 font-lock-keyword-face)
 
     ;; single quote characters
-    ("\\('[[:word:]]\\)\\>" 1 font-lock-constant-face)
+    ("'\\(\\\\.\\|[^']\\)'" . font-lock-constant-face)
 
     ;; Variables
     (,(odin-keywords-rx odin-builtins) 1 font-lock-variable-name-face)


### PR DESCRIPTION
Quick fix for single quotes. The second quote was not highlighted, and character literals containing a double quote (") would begin matching as a string.