### PR TITLE
add compilation-mode support

### DIFF
--- a/odin-mode.el
+++ b/odin-mode.el
@@ -17,6 +17,11 @@
   "Odin mode"
   :group 'languages)
 
+;; `compilation-mode' configuration
+
+(eval-after-load 'compile
+ '(add-to-list 'compilation-error-regexp-alist '("^\\(.*?\\)(\\([0-9]+\\):\\([0-9]+\\).*" 1 2 3)))
+
 (defconst odin-mode-syntax-table
   (let ((table (make-syntax-table)))
     (modify-syntax-entry ?\" "\"" table)


### PR DESCRIPTION
This pull request adds support to compilation-mode so that you can easily jump to errors using the built in functions of emacs.