### PR TITLE
Fix indent errors with non-standard tab-width variable.

### DIFF
--- a/odin-mode.el
+++ b/odin-mode.el
@@ -295,7 +295,8 @@
   (setq-local end-of-defun-function 'odin-end-of-defun)
   (setq-local electric-indent-chars
               (append "{}():;," electric-indent-chars))
-  (setq indent-tabs-mode t)
+  (setq-local indent-tabs-mode t)
+  (setq-local tab-width 2)
   (setq imenu-generic-expression
         `(("type" ,(concat "^" odin-type-rx) 1)
           ("proc" ,(concat "^" odin-proc-rx) 1)))


### PR DESCRIPTION
I don't know why, but js-indent-line works strange when tab-width equals 1. It would be better just to set it locally to 2.