### PR TITLE
update keyword `notin` -> `not_in` and add missing keywords

### DIFF
--- a/odin-mode.el
+++ b/odin-mode.el
@@ -74,12 +74,13 @@
 
 (defconst odin-keywords
   '("import" "foreign" "package"
-    "where" "when" "if" "else" "for" "switch" "in" "notin" "do" "case"
+    "where" "when" "if" "else" "for" "switch" "in" "not_in" "do" "case"
     "break" "continue" "fallthrough" "defer" "return" "proc"
     "struct" "union" "enum" "bit_field" "bit_set" "map" "dynamic"
     "auto_cast" "cast" "transmute" "distinct" "opaque"
     "using" "inline" "no_inline"
     "size_of" "align_of" "offset_of" "type_of"
+    "or_return" "or_else" "or_continue" "or_break"
 
     "context"
     ;; "_"


### PR DESCRIPTION
In [v0.13.0](https://github.com/odin-lang/Odin/releases/tag/v0.13.0) of odin the keyword was changed from notin to not_in.

Also keywords `or_return`, `or_else`, `or_continue` and `or_break` were added.